### PR TITLE
Add status-based tabs to verification page

### DIFF
--- a/client/pages/Verification.tsx
+++ b/client/pages/Verification.tsx
@@ -142,9 +142,7 @@ function SubmissionsList({
         <CardContent className="py-12">
           <div className="text-center">
             <FileX className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-            <p className="text-gray-500">
-              Tidak ada submission yang ditemukan
-            </p>
+            <p className="text-gray-500">Tidak ada submission yang ditemukan</p>
           </div>
         </CardContent>
       </Card>
@@ -154,7 +152,9 @@ function SubmissionsList({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Daftar Submission Readiness ({submissions.length})</CardTitle>
+        <CardTitle>
+          Daftar Submission Readiness ({submissions.length})
+        </CardTitle>
       </CardHeader>
       <CardContent>
         <div className="space-y-4">

--- a/client/pages/Verification.tsx
+++ b/client/pages/Verification.tsx
@@ -124,6 +124,98 @@ const STATUS_CONFIG = {
   },
 };
 
+// Submissions List Component
+interface SubmissionsListProps {
+  submissions: ProjectReadiness[];
+  onOpenModal: (submission: ProjectReadiness) => void;
+  getStatusBadge: (status: string) => JSX.Element | null;
+}
+
+function SubmissionsList({
+  submissions,
+  onOpenModal,
+  getStatusBadge,
+}: SubmissionsListProps) {
+  if (submissions.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-12">
+          <div className="text-center">
+            <FileX className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+            <p className="text-gray-500">
+              Tidak ada submission yang ditemukan
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Daftar Submission Readiness ({submissions.length})</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {submissions.map((submission) => (
+            <div
+              key={submission.id}
+              className="border rounded-lg p-4 hover:bg-gray-50 transition-colors"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex-1">
+                  <div className="flex items-center gap-3 mb-2">
+                    <h3 className="font-semibold text-gray-900">
+                      {submission.projectName}
+                    </h3>
+                    {getStatusBadge(submission.status)}
+                  </div>
+
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm text-gray-600">
+                    <div>
+                      <span className="font-medium">Submitter:</span>{" "}
+                      {submission.submittedBy}
+                    </div>
+                    <div>
+                      <span className="font-medium">Tanggal Submit:</span>{" "}
+                      {formatDateTime(submission.submittedAt)}
+                    </div>
+                    {submission.verifierName && (
+                      <div>
+                        <span className="font-medium">Verifier:</span>{" "}
+                        {submission.verifierName}
+                      </div>
+                    )}
+                  </div>
+
+                  {submission.overallComment && (
+                    <div className="mt-2 p-2 bg-gray-100 rounded text-sm">
+                      <span className="font-medium">Komentar:</span>{" "}
+                      {submission.overallComment}
+                    </div>
+                  )}
+                </div>
+
+                <div className="ml-4">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onOpenModal(submission)}
+                  >
+                    <Eye className="w-4 h-4 mr-2" />
+                    Review
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 export default function Verification() {
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("all");

--- a/client/pages/Verification.tsx
+++ b/client/pages/Verification.tsx
@@ -2,14 +2,8 @@ import { useState, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PageHeader } from "@/components/common/PageHeader";
 import { ProjectReadinessVerificationModal } from "@/components/verification/ProjectReadinessVerificationModal";
 import {
@@ -19,6 +13,7 @@ import {
   Clock,
   AlertTriangle,
   FileX,
+  Shield,
 } from "lucide-react";
 import type { ProjectReadiness } from "@/types";
 import { formatDateTime } from "@/utils/formatters";

--- a/client/pages/Verification.tsx
+++ b/client/pages/Verification.tsx
@@ -218,12 +218,12 @@ function SubmissionsList({
 
 export default function Verification() {
   const [searchTerm, setSearchTerm] = useState("");
-  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [activeTab, setActiveTab] = useState("all");
   const [selectedSubmission, setSelectedSubmission] =
     useState<ProjectReadiness | null>(null);
   const [verificationModal, setVerificationModal] = useState(false);
 
-  const filteredSubmissions = useMemo(() => {
+  const getFilteredSubmissions = (status: string) => {
     return mockReadinessSubmissions.filter((submission) => {
       const matchesSearch =
         submission.projectName
@@ -231,12 +231,11 @@ export default function Verification() {
           .includes(searchTerm.toLowerCase()) ||
         submission.submittedBy.toLowerCase().includes(searchTerm.toLowerCase());
 
-      const matchesStatus =
-        statusFilter === "all" || submission.status === statusFilter;
+      const matchesStatus = status === "all" || submission.status === status;
 
       return matchesSearch && matchesStatus;
     });
-  }, [searchTerm, statusFilter]);
+  };
 
   const openVerificationModal = (submission: ProjectReadiness) => {
     setSelectedSubmission(submission);

--- a/client/pages/Verification.tsx
+++ b/client/pages/Verification.tsx
@@ -340,114 +340,120 @@ export default function Verification() {
         </Card>
       </div>
 
-      {/* Filters */}
+      {/* Search */}
       <Card>
-        <CardHeader>
-          <CardTitle>Filter & Pencarian</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-col md:flex-row gap-4">
-            <div className="flex-1">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
-                <Input
-                  placeholder="Cari berdasarkan nama project atau submitter..."
-                  className="pl-10"
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                />
-              </div>
-            </div>
-
-            <div className="w-full md:w-48">
-              <Select value={statusFilter} onValueChange={setStatusFilter}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Status" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Semua Status</SelectItem>
-                  <SelectItem value="submitted">Menunggu Review</SelectItem>
-                  <SelectItem value="under_review">Sedang Direview</SelectItem>
-                  <SelectItem value="verified">Terverifikasi</SelectItem>
-                  <SelectItem value="needs_revision">Perlu Revisi</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+        <CardContent className="p-4">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+            <Input
+              placeholder="Cari berdasarkan nama project atau submitter..."
+              className="pl-10"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+            />
           </div>
         </CardContent>
       </Card>
 
-      {/* Submissions List */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Daftar Submission Readiness</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            {filteredSubmissions.length === 0 ? (
-              <div className="text-center py-8">
-                <FileX className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                <p className="text-gray-500">
-                  Tidak ada submission yang ditemukan
-                </p>
-              </div>
-            ) : (
-              filteredSubmissions.map((submission) => (
-                <div
-                  key={submission.id}
-                  className="border rounded-lg p-4 hover:bg-gray-50 transition-colors"
-                >
-                  <div className="flex items-center justify-between">
-                    <div className="flex-1">
-                      <div className="flex items-center gap-3 mb-2">
-                        <h3 className="font-semibold text-gray-900">
-                          {submission.projectName}
-                        </h3>
-                        {getStatusBadge(submission.status)}
-                      </div>
+      {/* Tabs for Status Tracking */}
+      <Tabs
+        value={activeTab}
+        onValueChange={setActiveTab}
+        className="space-y-6"
+      >
+        <TabsList className="grid w-full grid-cols-5">
+          <TabsTrigger value="all" className="flex items-center gap-2">
+            <Shield className="w-4 h-4" />
+            Semua ({mockReadinessSubmissions.length})
+          </TabsTrigger>
+          <TabsTrigger value="submitted" className="flex items-center gap-2">
+            <Clock className="w-4 h-4" />
+            Menunggu (
+            {
+              mockReadinessSubmissions.filter((s) => s.status === "submitted")
+                .length
+            }
+            )
+          </TabsTrigger>
+          <TabsTrigger value="under_review" className="flex items-center gap-2">
+            <Eye className="w-4 h-4" />
+            Review (
+            {
+              mockReadinessSubmissions.filter(
+                (s) => s.status === "under_review",
+              ).length
+            }
+            )
+          </TabsTrigger>
+          <TabsTrigger value="verified" className="flex items-center gap-2">
+            <CheckCircle className="w-4 h-4" />
+            Verified (
+            {
+              mockReadinessSubmissions.filter((s) => s.status === "verified")
+                .length
+            }
+            )
+          </TabsTrigger>
+          <TabsTrigger
+            value="needs_revision"
+            className="flex items-center gap-2"
+          >
+            <AlertTriangle className="w-4 h-4" />
+            Revisi (
+            {
+              mockReadinessSubmissions.filter(
+                (s) => s.status === "needs_revision",
+              ).length
+            }
+            )
+          </TabsTrigger>
+        </TabsList>
 
-                      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm text-gray-600">
-                        <div>
-                          <span className="font-medium">Submitter:</span>{" "}
-                          {submission.submittedBy}
-                        </div>
-                        <div>
-                          <span className="font-medium">Tanggal Submit:</span>{" "}
-                          {formatDateTime(submission.submittedAt)}
-                        </div>
-                        {submission.verifierName && (
-                          <div>
-                            <span className="font-medium">Verifier:</span>{" "}
-                            {submission.verifierName}
-                          </div>
-                        )}
-                      </div>
+        {/* Tab Content for All */}
+        <TabsContent value="all">
+          <SubmissionsList
+            submissions={getFilteredSubmissions("all")}
+            onOpenModal={openVerificationModal}
+            getStatusBadge={getStatusBadge}
+          />
+        </TabsContent>
 
-                      {submission.overallComment && (
-                        <div className="mt-2 p-2 bg-gray-100 rounded text-sm">
-                          <span className="font-medium">Komentar:</span>{" "}
-                          {submission.overallComment}
-                        </div>
-                      )}
-                    </div>
+        {/* Tab Content for Submitted */}
+        <TabsContent value="submitted">
+          <SubmissionsList
+            submissions={getFilteredSubmissions("submitted")}
+            onOpenModal={openVerificationModal}
+            getStatusBadge={getStatusBadge}
+          />
+        </TabsContent>
 
-                    <div className="ml-4">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => openVerificationModal(submission)}
-                      >
-                        <Eye className="w-4 h-4 mr-2" />
-                        Review
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              ))
-            )}
-          </div>
-        </CardContent>
-      </Card>
+        {/* Tab Content for Under Review */}
+        <TabsContent value="under_review">
+          <SubmissionsList
+            submissions={getFilteredSubmissions("under_review")}
+            onOpenModal={openVerificationModal}
+            getStatusBadge={getStatusBadge}
+          />
+        </TabsContent>
+
+        {/* Tab Content for Verified */}
+        <TabsContent value="verified">
+          <SubmissionsList
+            submissions={getFilteredSubmissions("verified")}
+            onOpenModal={openVerificationModal}
+            getStatusBadge={getStatusBadge}
+          />
+        </TabsContent>
+
+        {/* Tab Content for Needs Revision */}
+        <TabsContent value="needs_revision">
+          <SubmissionsList
+            submissions={getFilteredSubmissions("needs_revision")}
+            onOpenModal={openVerificationModal}
+            getStatusBadge={getStatusBadge}
+          />
+        </TabsContent>
+      </Tabs>
 
       {/* Verification Modal */}
       {verificationModal && selectedSubmission && (


### PR DESCRIPTION
## Purpose

The user requested to add a tabs feature to the `/verification` page that groups data based on status, similar to the existing `/risk-capture-verification` page. This enhancement improves the user experience by allowing better organization and filtering of verification submissions.

## Code changes

- **Replaced dropdown filter with tabs**: Removed the Select component and replaced it with a Tabs component from the UI library
- **Added status-based tab navigation**: Created 5 tabs (All, Menunggu, Review, Verified, Revisi) with dynamic counts showing the number of submissions in each status
- **Refactored submissions list**: Extracted the submissions display logic into a reusable `SubmissionsList` component
- **Updated filtering logic**: Changed from `statusFilter` state to `activeTab` state and modified the filtering function to work with tab-based navigation
- **Enhanced UI**: Added icons to each tab and improved the overall layout by simplifying the search section
- **Improved code organization**: Separated concerns by creating a dedicated component for rendering submission lists

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/c06a4152010a4b23b5d89fdd99052422/stellar-field)

👀 [Preview Link](https://c06a4152010a4b23b5d89fdd99052422-stellar-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c06a4152010a4b23b5d89fdd99052422</projectId>-->
<!--<branchName>stellar-field</branchName>-->