### PR TITLE
Add dialog for project readiness verification details

### DIFF
--- a/client/components/project/ProjectReadinessResults.tsx
+++ b/client/components/project/ProjectReadinessResults.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/utils/dataLoader";
 import { formatDateTime } from "@/utils/formatters";
 import type { ReadinessStatus } from "@/types";
+import { ReadinessDetailDialog } from "./ReadinessDetailDialog";
 
 interface UserComment {
   id: string;

--- a/client/components/project/ProjectReadinessResults.tsx
+++ b/client/components/project/ProjectReadinessResults.tsx
@@ -281,6 +281,28 @@ export function ProjectReadinessResults({
     });
   };
 
+  const openDetailDialog = (
+    type: "user-comments" | "verifier-feedback",
+    title: string,
+    data: any,
+  ) => {
+    setDetailDialog({
+      isOpen: true,
+      type,
+      title,
+      data,
+    });
+  };
+
+  const closeDetailDialog = () => {
+    setDetailDialog({
+      isOpen: false,
+      type: "user-comments",
+      title: "",
+      data: {},
+    });
+  };
+
   if (!readinessData) {
     return (
       <Dialog open={isOpen} onOpenChange={onClose}>

--- a/client/components/project/ProjectReadinessResults.tsx
+++ b/client/components/project/ProjectReadinessResults.tsx
@@ -588,32 +588,34 @@ export function ProjectReadinessResults({
                                       Feedback Risk Officer:
                                     </span>
                                   </div>
-                                  {item.verifiedAt && (
-                                    <span className="text-xs text-blue-600">
-                                      {new Date(item.verifiedAt).toLocaleString(
-                                        "id-ID",
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() =>
+                                      openDetailDialog(
+                                        "verifier-feedback",
+                                        item.title,
                                         {
-                                          day: "2-digit",
-                                          month: "2-digit",
-                                          year: "numeric",
-                                          hour: "2-digit",
-                                          minute: "2-digit",
+                                          verifierComment: item.verifierComment,
+                                          verifierName: item.verifierName,
+                                          verifiedAt: item.verifiedAt,
+                                          verifierStatus: item.verifierStatus,
                                         },
-                                      )}
-                                    </span>
-                                  )}
+                                      )
+                                    }
+                                    className="text-blue-600 border-blue-300 hover:bg-blue-50 h-7 px-2 text-xs"
+                                  >
+                                    Lihat Detail
+                                  </Button>
                                 </div>
-                                <div className="bg-white border border-blue-200 p-3 rounded">
-                                  <p className="text-sm text-blue-800 leading-relaxed">
-                                    {item.verifierComment}
+                                <div className="bg-white border border-blue-200 p-3 rounded text-center">
+                                  <p className="text-sm text-blue-700">
+                                    Feedback tersedia dari{" "}
+                                    {item.verifierName || "Risk Officer"}
                                   </p>
-                                  {item.verifierName && (
-                                    <div className="mt-2 pt-2 border-t border-blue-200">
-                                      <span className="text-xs text-blue-600 font-medium">
-                                        — {item.verifierName}
-                                      </span>
-                                    </div>
-                                  )}
+                                  <p className="text-xs text-blue-600 mt-1">
+                                    Klik "Lihat Detail" untuk melihat feedback lengkap
+                                  </p>
                                 </div>
                               </div>
                             ) : (

--- a/client/components/project/ProjectReadinessResults.tsx
+++ b/client/components/project/ProjectReadinessResults.tsx
@@ -666,6 +666,15 @@ export function ProjectReadinessResults({
           </div>
         </div>
       </DialogContent>
+
+      {/* Detail Dialog */}
+      <ReadinessDetailDialog
+        isOpen={detailDialog.isOpen}
+        onClose={closeDetailDialog}
+        type={detailDialog.type}
+        title={detailDialog.title}
+        data={detailDialog.data}
+      />
     </Dialog>
   );
 }

--- a/client/components/project/ProjectReadinessResults.tsx
+++ b/client/components/project/ProjectReadinessResults.tsx
@@ -533,50 +533,53 @@ export function ProjectReadinessResults({
 
                             {/* User Comments */}
                             {item.userComments &&
-                              item.userComments.length > 0 ? (
-                                <div className="bg-green-50 border border-green-200 p-3 rounded-lg">
-                                  <div className="flex items-center justify-between mb-2">
-                                    <div className="flex items-center gap-2">
-                                      <MessageSquare className="w-4 h-4 text-green-600" />
-                                      <span className="text-sm font-medium text-green-700">
-                                        Keterangan User ({item.userComments.length}):
-                                      </span>
-                                    </div>
-                                    <Button
-                                      variant="outline"
-                                      size="sm"
-                                      onClick={() =>
-                                        openDetailDialog(
-                                          "user-comments",
-                                          item.title,
-                                          {
-                                            userComments: item.userComments,
-                                            userStatus: item.userStatus,
-                                          },
-                                        )
-                                      }
-                                      className="text-green-600 border-green-300 hover:bg-green-50 h-7 px-2 text-xs"
-                                    >
-                                      Lihat Detail
-                                    </Button>
+                            item.userComments.length > 0 ? (
+                              <div className="bg-green-50 border border-green-200 p-3 rounded-lg">
+                                <div className="flex items-center justify-between mb-2">
+                                  <div className="flex items-center gap-2">
+                                    <MessageSquare className="w-4 h-4 text-green-600" />
+                                    <span className="text-sm font-medium text-green-700">
+                                      Keterangan User (
+                                      {item.userComments.length}):
+                                    </span>
                                   </div>
-                                  <div className="bg-white border border-green-200 p-3 rounded text-center">
-                                    <p className="text-sm text-green-700">
-                                      {item.userComments.length} keterangan tersedia
-                                    </p>
-                                    <p className="text-xs text-green-600 mt-1">
-                                      Klik "Lihat Detail" untuk melihat semua keterangan
-                                    </p>
-                                  </div>
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() =>
+                                      openDetailDialog(
+                                        "user-comments",
+                                        item.title,
+                                        {
+                                          userComments: item.userComments,
+                                          userStatus: item.userStatus,
+                                        },
+                                      )
+                                    }
+                                    className="text-green-600 border-green-300 hover:bg-green-50 h-7 px-2 text-xs"
+                                  >
+                                    Lihat Detail
+                                  </Button>
                                 </div>
-                              ) : (
-                                <div className="bg-gray-50 border border-gray-200 p-3 rounded-lg text-center">
-                                  <MessageSquare className="w-4 h-4 text-gray-400 mx-auto mb-1" />
-                                  <p className="text-sm text-gray-500 italic">
-                                    Belum ada keterangan dari user
+                                <div className="bg-white border border-green-200 p-3 rounded text-center">
+                                  <p className="text-sm text-green-700">
+                                    {item.userComments.length} keterangan
+                                    tersedia
+                                  </p>
+                                  <p className="text-xs text-green-600 mt-1">
+                                    Klik "Lihat Detail" untuk melihat semua
+                                    keterangan
                                   </p>
                                 </div>
-                              )}
+                              </div>
+                            ) : (
+                              <div className="bg-gray-50 border border-gray-200 p-3 rounded-lg text-center">
+                                <MessageSquare className="w-4 h-4 text-gray-400 mx-auto mb-1" />
+                                <p className="text-sm text-gray-500 italic">
+                                  Belum ada keterangan dari user
+                                </p>
+                              </div>
+                            )}
 
                             {/* Verifier Feedback */}
                             {item.verifierComment ? (
@@ -614,7 +617,8 @@ export function ProjectReadinessResults({
                                     {item.verifierName || "Risk Officer"}
                                   </p>
                                   <p className="text-xs text-blue-600 mt-1">
-                                    Klik "Lihat Detail" untuk melihat feedback lengkap
+                                    Klik "Lihat Detail" untuk melihat feedback
+                                    lengkap
                                   </p>
                                 </div>
                               </div>

--- a/client/components/project/ProjectReadinessResults.tsx
+++ b/client/components/project/ProjectReadinessResults.tsx
@@ -533,43 +533,48 @@ export function ProjectReadinessResults({
 
                             {/* User Comments */}
                             {item.userComments &&
-                              item.userComments.length > 0 && (
+                              item.userComments.length > 0 ? (
                                 <div className="bg-green-50 border border-green-200 p-3 rounded-lg">
-                                  <div className="flex items-center gap-2 mb-2">
-                                    <MessageSquare className="w-4 h-4 text-green-600" />
-                                    <span className="text-sm font-medium text-green-700">
-                                      Keterangan User (
-                                      {item.userComments.length}):
-                                    </span>
+                                  <div className="flex items-center justify-between mb-2">
+                                    <div className="flex items-center gap-2">
+                                      <MessageSquare className="w-4 h-4 text-green-600" />
+                                      <span className="text-sm font-medium text-green-700">
+                                        Keterangan User ({item.userComments.length}):
+                                      </span>
+                                    </div>
+                                    <Button
+                                      variant="outline"
+                                      size="sm"
+                                      onClick={() =>
+                                        openDetailDialog(
+                                          "user-comments",
+                                          item.title,
+                                          {
+                                            userComments: item.userComments,
+                                            userStatus: item.userStatus,
+                                          },
+                                        )
+                                      }
+                                      className="text-green-600 border-green-300 hover:bg-green-50 h-7 px-2 text-xs"
+                                    >
+                                      Lihat Detail
+                                    </Button>
                                   </div>
-                                  <div className="space-y-2">
-                                    {item.userComments.map((comment, index) => (
-                                      <div
-                                        key={comment.id}
-                                        className="bg-white border border-green-200 p-2 rounded"
-                                      >
-                                        <div className="flex items-center justify-between mb-1">
-                                          <span className="text-xs font-medium text-green-600">
-                                            Keterangan #{index + 1}
-                                          </span>
-                                          <span className="text-xs text-gray-500">
-                                            {new Date(
-                                              comment.createdAt,
-                                            ).toLocaleString("id-ID", {
-                                              day: "2-digit",
-                                              month: "2-digit",
-                                              year: "numeric",
-                                              hour: "2-digit",
-                                              minute: "2-digit",
-                                            })}
-                                          </span>
-                                        </div>
-                                        <p className="text-sm text-green-800 leading-relaxed">
-                                          {comment.text}
-                                        </p>
-                                      </div>
-                                    ))}
+                                  <div className="bg-white border border-green-200 p-3 rounded text-center">
+                                    <p className="text-sm text-green-700">
+                                      {item.userComments.length} keterangan tersedia
+                                    </p>
+                                    <p className="text-xs text-green-600 mt-1">
+                                      Klik "Lihat Detail" untuk melihat semua keterangan
+                                    </p>
                                   </div>
+                                </div>
+                              ) : (
+                                <div className="bg-gray-50 border border-gray-200 p-3 rounded-lg text-center">
+                                  <MessageSquare className="w-4 h-4 text-gray-400 mx-auto mb-1" />
+                                  <p className="text-sm text-gray-500 italic">
+                                    Belum ada keterangan dari user
+                                  </p>
                                 </div>
                               )}
 

--- a/client/components/project/ProjectReadinessResults.tsx
+++ b/client/components/project/ProjectReadinessResults.tsx
@@ -245,6 +245,17 @@ export function ProjectReadinessResults({
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
     new Set(),
   );
+  const [detailDialog, setDetailDialog] = useState<{
+    isOpen: boolean;
+    type: "user-comments" | "verifier-feedback";
+    title: string;
+    data: any;
+  }>({
+    isOpen: false,
+    type: "user-comments",
+    title: "",
+    data: {},
+  });
 
   useEffect(() => {
     if (isOpen && projectId) {

--- a/client/components/project/ReadinessDetailDialog.tsx
+++ b/client/components/project/ReadinessDetailDialog.tsx
@@ -1,0 +1,274 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import {
+  MessageSquare,
+  UserCheck,
+  User,
+  Calendar,
+  AlertTriangle,
+  CheckCircle,
+  XCircle,
+  X,
+} from "lucide-react";
+
+interface UserComment {
+  id: string;
+  text: string;
+  createdAt: string;
+}
+
+interface ReadinessDetailDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  type: "user-comments" | "verifier-feedback";
+  title: string;
+  data: {
+    userComments?: UserComment[];
+    userStatus?: string;
+    verifierComment?: string;
+    verifierName?: string;
+    verifiedAt?: string;
+    verifierStatus?: string;
+  };
+}
+
+const STATUS_CONFIG = {
+  lengkap: {
+    label: "Lengkap",
+    color: "bg-green-100 text-green-800",
+    icon: CheckCircle,
+  },
+  parsial: {
+    label: "Parsial",
+    color: "bg-yellow-100 text-yellow-800",
+    icon: AlertTriangle,
+  },
+  tidak_tersedia: {
+    label: "Tidak Tersedia",
+    color: "bg-red-100 text-red-800",
+    icon: XCircle,
+  },
+};
+
+const getStatusBadge = (status: string) => {
+  const config = STATUS_CONFIG[status as keyof typeof STATUS_CONFIG];
+  if (!config) return null;
+
+  const IconComponent = config.icon;
+  return (
+    <Badge className={config.color}>
+      <IconComponent className="w-3 h-3 mr-1" />
+      {config.label}
+    </Badge>
+  );
+};
+
+export function ReadinessDetailDialog({
+  isOpen,
+  onClose,
+  type,
+  title,
+  data,
+}: ReadinessDetailDialogProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
+        <DialogHeader className="pb-4 border-b">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              {type === "user-comments" ? (
+                <MessageSquare className="w-5 h-5 text-green-600" />
+              ) : (
+                <UserCheck className="w-5 h-5 text-blue-600" />
+              )}
+              <div>
+                <DialogTitle className="text-lg">
+                  {type === "user-comments"
+                    ? "Detail Keterangan User"
+                    : "Detail Feedback Risk Officer"}
+                </DialogTitle>
+                <DialogDescription className="text-sm font-medium mt-1">
+                  {title}
+                </DialogDescription>
+              </div>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onClose}
+              className="h-6 w-6 p-0"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto py-4 space-y-4">
+          {type === "user-comments" ? (
+            <>
+              {/* User Status */}
+              {data.userStatus && (
+                <div className="bg-gray-50 p-3 rounded-lg">
+                  <div className="flex items-center gap-2 mb-2">
+                    <User className="w-4 h-4 text-gray-600" />
+                    <span className="text-sm font-medium text-gray-700">
+                      Status Penilaian User:
+                    </span>
+                  </div>
+                  <div>{getStatusBadge(data.userStatus)}</div>
+                </div>
+              )}
+
+              {/* User Comments */}
+              {data.userComments && data.userComments.length > 0 ? (
+                <div className="space-y-3">
+                  <div className="flex items-center gap-2">
+                    <MessageSquare className="w-4 h-4 text-green-600" />
+                    <span className="text-sm font-medium text-green-700">
+                      Keterangan User ({data.userComments.length} komentar):
+                    </span>
+                  </div>
+                  <div className="space-y-3">
+                    {data.userComments.map((comment, index) => (
+                      <div
+                        key={comment.id}
+                        className="bg-green-50 border border-green-200 p-4 rounded-lg"
+                      >
+                        <div className="flex items-center justify-between mb-3">
+                          <span className="text-sm font-semibold text-green-700">
+                            Komentar #{index + 1}
+                          </span>
+                          <span className="text-xs text-green-600 bg-green-100 px-2 py-1 rounded">
+                            {new Date(comment.createdAt).toLocaleString("id-ID", {
+                              day: "2-digit",
+                              month: "short",
+                              year: "numeric",
+                              hour: "2-digit",
+                              minute: "2-digit",
+                            })}
+                          </span>
+                        </div>
+                        <div className="bg-white border border-green-200 p-3 rounded">
+                          <p className="text-sm text-green-800 leading-relaxed whitespace-pre-wrap">
+                            {comment.text}
+                          </p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <div className="text-center py-8">
+                  <MessageSquare className="w-12 h-12 text-gray-300 mx-auto mb-3" />
+                  <p className="text-sm text-gray-500">
+                    Belum ada keterangan dari user untuk item ini
+                  </p>
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              {/* Verifier Status */}
+              {data.verifierStatus && (
+                <div className="bg-gray-50 p-3 rounded-lg">
+                  <div className="flex items-center gap-2 mb-2">
+                    <UserCheck className="w-4 h-4 text-blue-600" />
+                    <span className="text-sm font-medium text-gray-700">
+                      Status Verifikasi Risk Officer:
+                    </span>
+                  </div>
+                  <div>{getStatusBadge(data.verifierStatus)}</div>
+                </div>
+              )}
+
+              {/* Verifier Information */}
+              {(data.verifierName || data.verifiedAt) && (
+                <div className="bg-blue-50 p-3 rounded-lg">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    {data.verifierName && (
+                      <div>
+                        <div className="flex items-center gap-2 mb-1">
+                          <UserCheck className="w-4 h-4 text-blue-600" />
+                          <span className="text-xs font-medium text-blue-700">
+                            Verifier:
+                          </span>
+                        </div>
+                        <p className="text-sm text-blue-800 font-medium">
+                          {data.verifierName}
+                        </p>
+                      </div>
+                    )}
+                    {data.verifiedAt && (
+                      <div>
+                        <div className="flex items-center gap-2 mb-1">
+                          <Calendar className="w-4 h-4 text-blue-600" />
+                          <span className="text-xs font-medium text-blue-700">
+                            Tanggal Verifikasi:
+                          </span>
+                        </div>
+                        <p className="text-sm text-blue-800">
+                          {new Date(data.verifiedAt).toLocaleString("id-ID", {
+                            day: "2-digit",
+                            month: "long",
+                            year: "numeric",
+                            hour: "2-digit",
+                            minute: "2-digit",
+                          })}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              <Separator />
+
+              {/* Verifier Feedback */}
+              {data.verifierComment ? (
+                <div className="space-y-3">
+                  <div className="flex items-center gap-2">
+                    <UserCheck className="w-4 h-4 text-blue-600" />
+                    <span className="text-sm font-medium text-blue-700">
+                      Feedback Risk Officer:
+                    </span>
+                  </div>
+                  <div className="bg-blue-50 border border-blue-200 p-4 rounded-lg">
+                    <div className="bg-white border border-blue-200 p-4 rounded">
+                      <p className="text-sm text-blue-800 leading-relaxed whitespace-pre-wrap">
+                        {data.verifierComment}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="text-center py-8">
+                  <UserCheck className="w-12 h-12 text-gray-300 mx-auto mb-3" />
+                  <p className="text-sm text-gray-500">
+                    Belum ada feedback dari Risk Officer untuk item ini
+                  </p>
+                  <p className="text-xs text-gray-400 mt-1">
+                    Feedback akan muncul setelah proses verifikasi selesai
+                  </p>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="pt-4 border-t">
+          <div className="flex justify-end">
+            <Button onClick={onClose}>Tutup</Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/components/project/ReadinessDetailDialog.tsx
+++ b/client/components/project/ReadinessDetailDialog.tsx
@@ -147,13 +147,16 @@ export function ReadinessDetailDialog({
                             Komentar #{index + 1}
                           </span>
                           <span className="text-xs text-green-600 bg-green-100 px-2 py-1 rounded">
-                            {new Date(comment.createdAt).toLocaleString("id-ID", {
-                              day: "2-digit",
-                              month: "short",
-                              year: "numeric",
-                              hour: "2-digit",
-                              minute: "2-digit",
-                            })}
+                            {new Date(comment.createdAt).toLocaleString(
+                              "id-ID",
+                              {
+                                day: "2-digit",
+                                month: "short",
+                                year: "numeric",
+                                hour: "2-digit",
+                                minute: "2-digit",
+                              },
+                            )}
                           </span>
                         </div>
                         <div className="bg-white border border-green-200 p-3 rounded">


### PR DESCRIPTION
## Purpose

The user identified that displaying multiple user comments and risk officer feedback directly in the Project Readiness verification results could become cluttered and difficult to read when there are many entries. They requested a solution to display this information in a focused dialog to improve readability and user experience.

## Code Changes

- **Added ReadinessDetailDialog component**: New dialog component to display detailed user comments and verifier feedback in a clean, organized format
- **Updated ProjectReadinessResults**: 
  - Added state management for dialog open/close and data passing
  - Replaced inline display of user comments and feedback with summary cards
  - Added "Lihat Detail" buttons to open the detail dialog
  - Improved visual hierarchy with better spacing and status indicators
- **Enhanced user experience**:
  - User comments now show count and summary instead of full content
  - Verifier feedback displays summary with verifier name and timestamp
  - Dialog provides comprehensive view with proper formatting and status badges
  - Added empty states for when no comments/feedback exist

The implementation maintains all existing functionality while providing a cleaner, more scalable interface for viewing verification details.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/c06a4152010a4b23b5d89fdd99052422/swoosh-haven)

👀 [Preview Link](https://c06a4152010a4b23b5d89fdd99052422-swoosh-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c06a4152010a4b23b5d89fdd99052422</projectId>-->
<!--<branchName>swoosh-haven</branchName>-->