### PR TITLE
Remove duplicate close button from ReadinessDetailDialog

### DIFF
--- a/client/components/project/ReadinessDetailDialog.tsx
+++ b/client/components/project/ReadinessDetailDialog.tsx
@@ -82,32 +82,22 @@ export function ReadinessDetailDialog({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
         <DialogHeader className="pb-4 border-b">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              {type === "user-comments" ? (
-                <MessageSquare className="w-5 h-5 text-green-600" />
-              ) : (
-                <UserCheck className="w-5 h-5 text-blue-600" />
-              )}
-              <div>
-                <DialogTitle className="text-lg">
-                  {type === "user-comments"
-                    ? "Detail Keterangan User"
-                    : "Detail Feedback Risk Officer"}
-                </DialogTitle>
-                <DialogDescription className="text-sm font-medium mt-1">
-                  {title}
-                </DialogDescription>
-              </div>
+          <div className="flex items-center gap-3">
+            {type === "user-comments" ? (
+              <MessageSquare className="w-5 h-5 text-green-600" />
+            ) : (
+              <UserCheck className="w-5 h-5 text-blue-600" />
+            )}
+            <div>
+              <DialogTitle className="text-lg">
+                {type === "user-comments"
+                  ? "Detail Keterangan User"
+                  : "Detail Feedback Risk Officer"}
+              </DialogTitle>
+              <DialogDescription className="text-sm font-medium mt-1">
+                {title}
+              </DialogDescription>
             </div>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onClose}
-              className="h-6 w-6 p-0"
-            >
-              <X className="h-4 w-4" />
-            </Button>
           </div>
         </DialogHeader>
 

--- a/client/components/project/ReadinessDetailDialog.tsx
+++ b/client/components/project/ReadinessDetailDialog.tsx
@@ -16,7 +16,6 @@ import {
   AlertTriangle,
   CheckCircle,
   XCircle,
-  X,
 } from "lucide-react";
 
 interface UserComment {


### PR DESCRIPTION
## Purpose
Remove duplicate close button from the ReadinessDetailDialog component. The user identified that there were duplicate close buttons in both the Detail Project and Project Readiness Verification dialogs, creating redundant UI elements.

## Code changes
- Removed the custom close button from the dialog header in `ReadinessDetailDialog.tsx`
- Removed unused `X` icon import from lucide-react
- Simplified the header layout by removing the flex justify-between wrapper
- The dialog now relies on the default close functionality provided by the Dialog component

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/009b67e4f34d40b0b3a68be3acd4000a/echo-space)

👀 [Preview Link](https://009b67e4f34d40b0b3a68be3acd4000a-echo-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>009b67e4f34d40b0b3a68be3acd4000a</projectId>-->
<!--<branchName>echo-space</branchName>-->